### PR TITLE
Correct paths in “Changing the logo”

### DIFF
--- a/docs/content/administration/customizing-gitea.en-us.md
+++ b/docs/content/administration/customizing-gitea.en-us.md
@@ -64,14 +64,14 @@ the url `http://gitea.domain.tld/assets/image.png`.
 ## Changing the logo
 
 To build a custom logo and/or favicon clone the Gitea source repository, replace `assets/logo.svg` and/or `assets/favicon.svg` and run
-`make generate-images`. `assets/favicon.svg` is used for the favicon only. This will update below output files which you can then place in `$GITEA_CUSTOM/public/assets/img` on your server:
+`make generate-images`. `assets/favicon.svg` is used for the favicon only. This will update below output files which you can then place in `$GITEA_CUSTOM/public/img` on your server:
 
-- `public/assets/img/logo.svg` - Used for site icon, app icon
-- `public/assets/img/logo.png` - Used for Open Graph
-- `public/assets/img/avatar_default.png` - Used as the default avatar image
-- `public/assets/img/apple-touch-icon.png` - Used on iOS devices for bookmarks
-- `public/assets/img/favicon.svg` - Used for favicon
-- `public/assets/img/favicon.png` - Used as fallback for browsers that don't support SVG favicons
+- `public/img/logo.svg` - Used for site icon, app icon
+- `public/img/logo.png` - Used for Open Graph
+- `public/img/avatar_default.png` - Used as the default avatar image
+- `public/img/apple-touch-icon.png` - Used on iOS devices for bookmarks
+- `public/img/favicon.svg` - Used for favicon
+- `public/img/favicon.png` - Used as fallback for browsers that don't support SVG favicons
 
 In case the source image is not in vector format, you can attempt to convert a raster image using tools like [this](https://www.aconvert.com/image/png-to-svg/).
 


### PR DESCRIPTION
Some paths in this document previously looked like `public/assets/img/...`, but it looks like the URL “/assets/...” is served from the path `public/...`, so the `assets` directory needs to be removed from the path. I think this change needs to be made for others paths in this document, but I am not familiar with them, so I have not changed them. I have tested this on [v1.20.2+1](https://gitlab.com/packaging/gitea/-/tags/v1.20.2+1).